### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/with-static-export-app/README.md
+++ b/with-static-export-app/README.md
@@ -9,6 +9,7 @@ When trying to run `npm start` it will build and export your pages into the `out
 Preview the example live on [StackBlitz](http://stackblitz.com/):
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-static-export)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/egriboz/egriboz.github.io)
 
 ## How to use
 


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.